### PR TITLE
Fix out of bounds error in "engineering" exponent mode

### DIFF
--- a/src/impl/num/process.typ
+++ b/src/impl/num/process.typ
@@ -122,6 +122,9 @@
     } else if integer == "0" {
       let i = decimal.position(non-zero-integer-regex)
       let l = 3 - calc.rem(i, 3)
+      while decimal.len() < i+l {
+        decimal = decimal + "0" 
+      }
       integer = decimal.slice(i, i+l)
       decimal = decimal.slice(i+l)
       exponent -= i+l


### PR DESCRIPTION
In 0.3.0, 

```
#num(0.1, exponent-mode: "engineering")
```
breaks with an out of bounds exception.

Longer example with relevant exponent range:

```typst

// This line is optional, but it makes formatting of the positive exponents nicer  
// #metro-setup(drop-zero-decimal: true)

#let fn(number) = (
  [#num(number)], 
  [#num(number, exponent-mode: "engineering")],
  [#num(number, exponent-mode: "scientific")],
  [#num(number, exponent-mode: "threshold")],
)

#table(columns: 4,
table.header([Normal], [Engineering], [Scientific], [Threshold]), 
..(for exp in range(-6, 6) {
  fn(1 * calc.pow(10, exp))
})
)

```