### PR TITLE
Correct number of significant digits for cases like 1.0000001

### DIFF
--- a/src/impl/num/process.typ
+++ b/src/impl/num/process.typ
@@ -207,9 +207,15 @@
     }
     
     let len = integer.len() + decimal.len()
+    let check-add-zeros = false
     if options.round-precision < len {
-      (integer, decimal) = round-digits(integer, decimal, options.round-precision + if integer.len() < options.round-precision { decimal.position(non-zero-integer-regex) })
-    } else if len < options.round-precision and options.round-pad {
+      (integer, decimal) = round-digits(integer, decimal, options.round-precision)
+      // Do we have too few significant digits now? (e.g. round 1.0009 to three 
+      // significant digits -> return 1.00 instead of 1)
+      let len = integer.len() + decimal.len()
+      check-add-zeros = true
+    } 
+    if len < options.round-precision and (check-add-zeros or options.round-pad) {
       decimal += "0" * (options.round-precision - len)
     }
   }


### PR DESCRIPTION
```typst
#metro-setup(round-mode: "figures", round-precision: 4, round-pad: false)

#let fn(number) = (
  [#num(number, round-mode: "none")], 
  [#num(number, exponent-mode: "engineering")],
  [#num(number, exponent-mode: "scientific")],
  [#num(number, exponent-mode: "scientific", round-pad: true)],
  [#num(number, exponent-mode: "threshold")],
)

#table(columns: 5,
table.header([Normal], [Engineering], [Scientific], [Scientific-padded], [Threshold]), 
..(for exp in range(-5, 0) {
  fn(1 + 9*calc.pow(10, exp))
}),
..(for exp in range(0, 6) {
  fn(9 + 1*calc.pow(10, exp))
})
)
```
previously displayed:

![image](https://github.com/user-attachments/assets/f256330e-2e6e-4b5f-ae46-c90af9fc23d6)


In the first / last rows, there are more significant digits than requested.

The new code displays

![image](https://github.com/user-attachments/assets/7732230f-9cd5-4165-8733-50d0e0cd64a1)


which is in line with 

```tex
\documentclass[10pt,a4paper]{article}
\usepackage[T1]{fontenc}
\usepackage{siunitx}
\usepackage{tabularx}
\begin{document}
	\sisetup{round-mode = figures, round-precision=4, round-pad = false }
	\begin{table}
		\caption{Thresholds for exponents.%
			\label{tab:threshold}}
		\begin{tabular}
			{
				@{}
				S[round-mode = none]
				S[exponent-mode = engineering]
				S[exponent-mode = scientific]
				S[exponent-mode = scientific, round-pad = true]
				S[exponent-mode = threshold]
				@{}
			}
			{Input} & {Engineering} & {Scientific} & {Scientific-padded} & {Threshold} \\
			1.00009 & 1.00009 & 1.00009 & 1.00009 & 1.00009\\
			1.0009 & 1.0009 & 1.0009 & 1.0009 & 1.0009\\
			1.009 & 1.009 & 1.009 & 1.009 & 1.009\\
			1.09 & 1.09 & 1.09 & 1.09 & 1.09\\
			1.9 & 1.9 & 1.9 & 1.9 & 1.9\\
			10 & 10 & 10 & 10 & 10\\
			19 & 19 & 19 & 19 & 19\\
			109 & 109 & 109 & 109 & 109\\
			1009 & 1009 & 1009 & 1009 & 1009\\
			10009 & 10009 & 10009 & 10009 & 10009\\
			100009 & 100009 & 100009 & 100009 & 100009\\
			
		\end{tabular}
	\end{table}
\end{document}
```

which outputs


![image](https://github.com/user-attachments/assets/22f712eb-b066-4a47-8943-a09280135948)

There might be some merit to adding special handling for numerical inaccuracies like

```typst
#metro-setup(round-mode: "figures", round-precision: 10, round-pad: false)
#num(1.23456 * calc.pow(10, -3), round-mode: "none") $arrow$
#num(1.23456 * calc.pow(10, -3), exponent-mode: "scientific")
```

but maybe using decimals (ongoing upstream work) solves that in userspace.