### PR TITLE
make typst 0.13 compatible

### DIFF
--- a/src/defs/units.typ
+++ b/src/defs/units.typ
@@ -4,7 +4,7 @@
 // SI units
 #let ampere = $A$
 #let candela = $c d$
-#let kelvin = $kelvin$
+#let kelvin = $upright(K)$
 #let kilogram = $k#gram$
 #let metre = $m$
 #let meter = metre
@@ -14,7 +14,7 @@
 
 // Derived units
 #let becquerel = $B q$
-#let degreeCelsius = $degree.c$
+#let degreeCelsius = $upright(degree C)$
 #let coulomb = $C$
 #let farad = $F$
 #let gray = $G y$
@@ -25,7 +25,7 @@
 #let katal = $k a t$
 #let lux = $l x$
 #let newton = $N$
-#let ohm = $ohm$
+#let ohm = $Omega$
 #let pascal = $P a$
 #let radian = $r a d$
 #let siemens = $S$
@@ -223,7 +223,7 @@
 
   degree: sym.degree,
 
-  degreeCelsius: sym.degree.c,
+  degreeCelsius: degreeCelsius,
 
   coulomb: coulomb,
   C: coulomb,

--- a/src/impl/unit.typ
+++ b/src/impl/unit.typ
@@ -45,9 +45,9 @@
     } else if input.class == "binary" and input.body == [per] {
       (is-per: true, body: NULL-before)
     }
-  } else if func in ("text", "equation", "display") {
+  } else if func in ("text", "equation", "display", "symbol") {
     (
-      body: if func == "text" {
+      body: if func in ("text", "symbol") {
         input.text
       } else {
         input.body
@@ -208,7 +208,7 @@
 
 #let unit(unit, options) = {
   let input = unit
-  assert(type(input) in (str, content), message: "Expected string or content input type, got " + type(input) + " instead.")
+  assert(type(input) in (str, content), message: "Expected string or content input type, got " + str(type(input)) + " instead.")
   options = get-options(options)
 
   if type(input) == str {


### PR DESCRIPTION
Typst 0.13 will remove some symbols and make type and str incompatible. Adjust the relevant places in the code to be compatible with those changes.

Fixes: #27 
Fixes: #28 