### PR TITLE
Add `degreeFahrenheit` and temperatures aliases/shortcuts

### DIFF
--- a/src/defs/units.typ
+++ b/src/defs/units.typ
@@ -15,6 +15,9 @@
 // Derived units
 #let becquerel = $B q$
 #let degreeCelsius = $degree C$
+#let degreeFahrenheit = $degree F$
+#let celsius = degreeCelsius
+#let fahrenheit = degreeFahrenheit
 #let coulomb = $C$
 #let farad = $F$
 #let gray = $G y$
@@ -224,6 +227,10 @@
   degree: sym.degree,
 
   degreeCelsius: degreeCelsius,
+  degreeFahrenheit: degreeFahrenheit,
+
+  celsius: degreeCelsius,
+  fahrenheit: degreeFahrenheit,
 
   coulomb: coulomb,
   C: coulomb,

--- a/src/defs/units.typ
+++ b/src/defs/units.typ
@@ -4,7 +4,7 @@
 // SI units
 #let ampere = $A$
 #let candela = $c d$
-#let kelvin = $kelvin$
+#let kelvin = $K$
 #let kilogram = $k#gram$
 #let metre = $m$
 #let meter = metre
@@ -14,7 +14,7 @@
 
 // Derived units
 #let becquerel = $B q$
-#let degreeCelsius = $degree.c$
+#let degreeCelsius = $degree C$
 #let coulomb = $C$
 #let farad = $F$
 #let gray = $G y$
@@ -25,7 +25,7 @@
 #let katal = $k a t$
 #let lux = $l x$
 #let newton = $N$
-#let ohm = $ohm$
+#let ohm = $Omega$
 #let pascal = $P a$
 #let radian = $r a d$
 #let siemens = $S$
@@ -223,7 +223,7 @@
 
   degree: sym.degree,
 
-  degreeCelsius: sym.degree.c,
+  degreeCelsius: degreeCelsius,
 
   coulomb: coulomb,
   C: coulomb,


### PR DESCRIPTION
This PR:

- Adds the unit `degreeFahrenheit`, similar to the existing `degreeCelsius`;
- Adds the unit `fahrenheit` as an alias to `degreeFahrenheit`;
- Adds the unit `celsius` as an alias to `degreeCelsius`;

## Example

Working example:
```typst
#import "/src/lib.typ": qty

$ qty(10, "degreeCelsius") = qty(10, "celsius") $
$ qty(10, "degreeFahrenheit") = qty(10, "fahrenheit") $
```
Output:
![image](https://github.com/user-attachments/assets/6970ea0f-156b-4096-a5b0-b60c65f42038)
